### PR TITLE
長いパスを省略表示したい

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,25 @@ zstyle ':prompt:backward' enable t
 zstyle ':prompt:backward:dir' formats "%U%a%u"
 zstyle ':prompt:backward:dir:symlink' formats "%U%F{cyan}%a@%f%u"
 zstyle ':prompt:backward:way' formats "%a"
+
+## パス省略表示
+# 省略記号 (default: ...)
+#zstyle ':prompt:truncate' symbol '… '
+
+# パス最大長 (default: 30)
+#zstyle ':prompt:truncate' max_length 40
+
+# カレントディレクトリの親ディレクトリを表示する (default: no)
+zstyle ":prompt:truncate" show_working_parent yes
+
+# 前ディレクトリの親ディレクトリを表示する (default: no)
+# zstyle ":prompt:truncate" show_backward_parent yes
+
+# "/" 直下のディレクトリを表示する (default: no)
+zstyle ":prompt:truncate" show_slash_second_root yes
+
+# "~/" 直下のディレクトリを表示する (default: no)
+zstyle ":prompt:truncate" show_home_second_root yes
 ```
 
 add-zsh-hook の chpwd とかでプロンプトを更新    


### PR DESCRIPTION
こんな感じに良い感じに省略表示したい。

![promptway_truncate_demo](https://f.cloud.github.com/assets/733116/791250/025829d2-eb3e-11e2-9068-17a995c17934.png)

以下のオプションである程度いじれるようにしてます。

``` bash
# 省略記号 (型: String, default: ...)
zstyle ':prompt:truncate' symbol

# パス最大長 (型: String, default: 30)
zstyle ':prompt:truncate' max_length

# カレントディレクトリの親ディレクトリを表示する (型: Boolean, default: no)
zstyle ":prompt:truncate" show_working_parent

# 前ディレクトリの親ディレクトリを表示する (型: Boolean, default: no)
zstyle ":prompt:truncate" show_backward_parent

# "/" 直下のディレクトリを表示する (型: Boolean, default: no)
zstyle ":prompt:truncate" show_slash_second_root

# "~/" 直下のディレクトリを表示する (型: Boolean, default: no)
zstyle ":prompt:truncate" show_home_second_root
```

上の画像は以下の設定で実行した結果です。
(赤色がカレントディレクトリ、下線が前のディレクトリ)

``` bash
zstyle ':prompt:truncate' symbol '… '
zstyle ":prompt:truncate" show_working_parent yes
zstyle ":prompt:truncate" show_slash_second_root yes
```

どうでしょう。
自分はいつも1画面を狭くして作業してるので、省略表示がどうしても欲しいです。

ご検討お願いします。
