### PR TITLE
初期化処理の一部を promptway 内で実行する

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,6 @@ source promptway.zsh
 まずは設定をする
 
 ```sh
-
-source path/to/promptway/promptway.zsh
-
 zstyle ':prompt:dir' formats "%B%a%b"
 zstyle ':prompt:dir:symlink' formats "%B%F{cyan}%a@%f%b"
 zstyle ':prompt:way' formats "%a"
@@ -56,20 +53,17 @@ zstyle ":prompt:truncate" show_slash_second_root t
 
 # "~/" 直下のディレクトリを表示する (default: 無効)
 zstyle ":prompt:truncate" show_home_second_root t
+
+## Source promptway.zsh
+# zstyle による設定後に読み込むこと
+source path/to/promptway/promptway.zsh
 ```
 
-add-zsh-hook の chpwd とかでプロンプトを更新
-`promptway` 関数を呼ぶと `$_prompt_way` ってグローバル変数に情報が入ります。
+`$_prompt_way` 変数にパス情報が設定されるので、`PROMPT` などに設定して利用します。
 
 ```sh
-
 setopt prompt_subst
 PROMPT='$_prompt_way'
-
-autoload -U add-zsh-hook
-add-zsh-hook chpwd promptway
-
-promptway # Initializes $_prompt_way first.
 ```
 
 たとえば `~/Documents` から `~/Downloads` に移動した場合、 `$_prompt_backward` に情報が入ります。つまり `~/Documents` に `popd` で戻れるディレクトリの位置が保存されます。

--- a/promptway.zsh
+++ b/promptway.zsh
@@ -320,3 +320,10 @@ _promptway_slash () {
     echo ""
   fi
 }
+
+if ! (( $+functions[add-zsh-hook] )); then
+  autoload -U add-zsh-hook
+fi
+add-zsh-hook chpwd promptway
+
+promptway


### PR DESCRIPTION
`chpwd` 用の hook 関数の登録と、`promptway` 関数の初回実行 を promptway 内で実行するようにしてみました。
そのかわり `source /path/to/promptway.zsh` を `zstyle` による設定後に行う必要があります。

どうでしょうか。
賛否両論あるかも。

よろしくお願いします。
