### PR TITLE
細かい修正をいくつか

### DIFF
--- a/lib/promptway.zsh
+++ b/lib/promptway.zsh
@@ -1,6 +1,6 @@
 # -*- sh -*-
 
-zstyle -s "prompt:pathf" path _cmd_pathf
+zstyle -s ":prompt:pathf" path _cmd_pathf
 if [[ -z $_cmd_pathf ]]; then
   _cmd_pathf=$(whence -p pathf)
   if [[ -z $_cmd_pathf ]]; then
@@ -14,7 +14,7 @@ if [[ -z $_cmd_pathf ]]; then
     fi
     _cmd_pathf="${_cmd_pathf}/../.vendor/pathf/bin/pathf"
   fi
-  zstyle "prompt:pathf" path "$_cmd_pathf"
+  zstyle ":prompt:pathf" path "$_cmd_pathf"
 fi
 
 if ! whence -p "$_cmd_pathf" > /dev/null 2>&1; then
@@ -41,7 +41,7 @@ promptway () {
     _is_truncate _symbol _max_length \
     _show_working_parent _show_backward_parent _pdsymbol _pbsymbol \
     _show_slash_second_root _show_home_second_root
-  zstyle -s "prompt:pathf" path _cmd_pathf
+  zstyle -s ":prompt:pathf" path _cmd_pathf
   zstyle -a ":prompt:way" formats _wwfmt
   zstyle -a ":prompt:dir" formats _wdfmt
   zstyle -a ":prompt:dir:symlink" formats _wdsymfmt
@@ -264,7 +264,7 @@ _promptway_backward () {
   _prompt_backward=
   local _cmd_pathf _pbsymbol _bperm
   local -a _is_bwenable _bwdfmt _bwwfmt _pbfmt
-  zstyle -s "prompt:pathf" path _cmd_pathf
+  zstyle -s ":prompt:pathf" path _cmd_pathf
   zstyle -a ":prompt:backward" enable _is_bwenable
   zstyle -a ":prompt:backward:dir" formats _bwdfmt
   zstyle -a ":prompt:backward:way" formats _bwwfmt

--- a/lib/promptway.zsh
+++ b/lib/promptway.zsh
@@ -36,11 +36,12 @@ promptway () {
   _prompt_way=
   local -a _result
   local -a _wwfmt _wdfmt _wdsymfmt
-  local -a _is_bwenable _bwdfmt _bwwfmt _bwdsymfmt _pdfmt _pbfmt
-  local _cmd_pathf _way _bperm _dir_slash _way_slash \
-    _is_truncate _symbol _max_length \
-    _show_working_parent _show_backward_parent _pdsymbol _pbsymbol \
+  local -a _is_bwenable _bwdfmt _bwwfmt _bwdsymfmt
+  local -a _is_truncate _show_working_parent _show_backward_parent \
     _show_slash_second_root _show_home_second_root
+  local -a _pdfmt _pbfmt
+  local _cmd_pathf _way _bperm _dir_slash _way_slash \
+    _symbol _max_length _pdsymbol _pbsymbol
   zstyle -s ":prompt:pathf" path _cmd_pathf
   zstyle -a ":prompt:way" formats _wwfmt
   zstyle -a ":prompt:dir" formats _wdfmt

--- a/promptway.zsh
+++ b/promptway.zsh
@@ -53,6 +53,18 @@ zstyle ":prompt:truncate" show_slash_second_root ""
 # "~/" 直下のディレクトリを表示する (default: 無効)
 zstyle ":prompt:truncate" show_home_second_root ""
 
+## Permissions of the current directory
+# Format of permissions
+zstyle ':prompt:permission:dir' formats ""
+# Non owner symbol
+zstyle ':prompt:permission:dir' non_owner_symbol ""
+
+## Permissions of the backward directory
+# Format of permissions
+zstyle ':prompt:permission:backward' formats ""
+# Non owner symbol
+zstyle ':prompt:permission:backward' non_owner_symbol ""
+
 
 
 


### PR DESCRIPTION
細かすぎたのでまとめて修正
-  zstyle "prompt:pathf" を zstyle ":prompt:pathf" に修正 (先頭コロン(:)抜けてた)
- パーミッション表示オプションのデフォルト値を `promptway/promptway.zsh` に書くの忘れてました
- 配列型の変数宣言の一部に `-a` つけ忘れてたので修正、あとちょっと並び替えしました

よろしくお願いします。
