### PR TITLE
named directory の省略表示に対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ zstyle ":prompt:truncate" show_slash_second_root t
 # "~/" 直下のディレクトリを表示する (default: 無効)
 zstyle ":prompt:truncate" show_home_second_root t
 
+# 名前付きディレクトリ直下のディレクトリを表示する (default: 無効)
+# zstyle ':prompt:truncate' show_named_dir_second_root t
+
 ## カレントディレクトリの Permission 表示
 # Permission のフォーマット
 zstyle ':prompt:permission:dir' formats '(%F{yellow}%a%b%f)'

--- a/lib/promptway.zsh
+++ b/lib/promptway.zsh
@@ -38,7 +38,7 @@ promptway () {
   local -a _wwfmt _wdfmt _wdsymfmt
   local -a _is_bwenable _bwdfmt _bwwfmt _bwdsymfmt
   local -a _is_truncate _show_working_parent _show_backward_parent \
-    _show_slash_second_root _show_home_second_root
+    _show_slash_second_root _show_home_second_root _show_named_dir_second_root
   local -a _pdfmt _pbfmt
   local _cmd_pathf _way _bperm _dir_slash _way_slash \
     _symbol _max_length _pdsymbol _pbsymbol
@@ -57,6 +57,7 @@ promptway () {
   zstyle -a ":prompt:truncate" show_backward_parent _show_backward_parent
   zstyle -a ":prompt:truncate" show_slash_second_root _show_slash_second_root
   zstyle -a ":prompt:truncate" show_home_second_root _show_home_second_root
+  zstyle -a ":prompt:truncate" show_named_dir_second_root _show_named_dir_second_root
   zstyle -a ":prompt:permission:dir" formats _pdfmt
   zstyle -s ":prompt:permission:dir" non_owner_symbol _pdsymbol
   zstyle -a ":prompt:permission:backward" formats _pbfmt
@@ -145,9 +146,11 @@ promptway () {
     if [[ -n $_is_truncate ]] \
       && _promptway_is_max_length_over "$_prompt_way" "$_max_length"; then
       _bupw=$(_promptway_truncate "$_bupw" "$_symbol" \
-        "$_show_working_parent" "$_show_slash_second_root" "$_show_home_second_root")
+        "$_show_working_parent" "$_show_slash_second_root" "$_show_home_second_root" \
+        "$_show_named_dir_second_root")
       _prompt_way=$(_promptway_truncate "$_way" "$_symbol" \
-        "$_show_backward_parent" "$_show_slash_second_root" "$_show_home_second_root")
+        "$_show_backward_parent" "$_show_slash_second_root" "$_show_home_second_root" \
+        "$_show_named_dir_second_root")
       _prompt_way="$_prompt_way$_bupd$_bperm$_dir_slash$_bupw$_way_slash$_wd"
     fi
   elif [[ -n $BACKWARD_UNDER_WAY ]] || [[ -n $BACKWARD_UNDER_DIR ]]; then
@@ -170,9 +173,11 @@ promptway () {
     if [[ -n $_is_truncate ]] \
       && _promptway_is_max_length_over "$_prompt_way" "$_max_length"; then
       _budw=$(_promptway_truncate "$_budw" "$_symbol" \
-        "$_show_backward_parent" "$_show_slash_second_root" "$_show_home_second_root")
+        "$_show_backward_parent" "$_show_slash_second_root" "$_show_home_second_root" \
+        "$_show_named_dir_second_root")
       _prompt_way=$(_promptway_truncate "$_way" "$_symbol" \
-        "$_show_working_parent" "$_show_slash_second_root" "$_show_home_second_root")
+        "$_show_working_parent" "$_show_slash_second_root" "$_show_home_second_root" \
+        "$_show_named_dir_second_root")
       _prompt_way="$_prompt_way$_wd$_dir_slash$_budw$_way_slash$_budd$_bperm"
     fi
   else
@@ -181,7 +186,8 @@ promptway () {
     if [[ -n $_is_truncate ]] \
       && _promptway_is_max_length_over "$_prompt_way" "$_max_length"; then
       _prompt_way=$(_promptway_truncate "$_way" "$_symbol" \
-        "$_show_working_parent" "$_show_slash_second_root" "$_show_home_second_root")
+        "$_show_working_parent" "$_show_slash_second_root" "$_show_home_second_root" \
+        "$_show_named_dir_second_root")
       _prompt_way="$_prompt_way$_wd"
     fi
   fi
@@ -240,6 +246,7 @@ _promptway_truncate() {
   local show_base="$3"
   local show_slash_root="$4"
   local show_home_root="$5"
+  local show_named_dir_root="$6"
 
   local prefix suffix
 
@@ -254,10 +261,17 @@ _promptway_truncate() {
   elif [[ $_path != ${_path#\~/} ]]; then
     prefix='~/'
     _path=${_path#\~/}
+  elif [[ $_path != ${_path#\~*/} ]]; then
+    prefix="${_path%%/*}/"
+    _path=${_path#\~*/}
+  elif [[ $_path != ${_path#\~} ]]; then
+    prefix="$_path"
+    _path=
   fi
 
   if [[ -n $show_slash_root && $prefix == '/' \
-    || -n $show_home_root && $prefix == '~/'  ]]; then
+    || -n $show_home_root && $prefix == '~/'  \
+    || -n $show_named_dir_root && $prefix =~ '^~[^/]' ]]; then
     if [[ $_path =~ '/' ]]; then
       prefix+="${_path%%/*}/"
       _path=${_path#*/}

--- a/promptway.zsh
+++ b/promptway.zsh
@@ -53,6 +53,9 @@ zstyle ":prompt:truncate" show_slash_second_root ""
 # "~/" 直下のディレクトリを表示する (default: 無効)
 zstyle ":prompt:truncate" show_home_second_root ""
 
+# 名前付きディレクトリ直下のディレクトリを表示する (default: 無効)
+zstyle ':prompt:truncate' show_named_dir_second_root ""
+
 ## Permissions of the current directory
 # Format of permissions
 zstyle ':prompt:permission:dir' formats ""


### PR DESCRIPTION
名前付きディレクトリで、パスが長い場合の省略表示に対応してなかったので対応しました。

修正前

![github-isuue01](https://f.cloud.github.com/assets/733116/866914/7d89509e-f6c0-11e2-8564-98fbea747d54.png)

修正後

![github-isuue02](https://f.cloud.github.com/assets/733116/866915/872489ac-f6c0-11e2-96cd-e26f0bb5696e.png)
